### PR TITLE
Bug in Invoke-TeamCityCiUpload.Tests.ps1 from 'Improving logging interaction with TeamCity'

### DIFF
--- a/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.Tests.ps1
@@ -103,9 +103,9 @@ Describe "Invoke-TeamCityCiUpload" {
      
      It "Should handle only a single file being returned from Get-ChildItem in individual mode" {
          New-StepTemplate -Name "test3" -Path "TestDrive:\" 
-         Mock Get-ChildItem { @{Name = "test3.steptemplate.ps1"; FullName = "TestDrive:\test3.steptemplate.ps1" } } -ParameterFilter { $Filter -eq "*.steptemplate.ps1" }
+         Mock Get-ChildItem { @{Name = "test3.steptemplate.ps1"; FullName = "TestDrive:\test3.steptemplate.ps1"; BaseName = "test3.steptemplate" } } -ParameterFilter { $Filter -eq "*.steptemplate.ps1" }
          New-ScriptModule -Name "test4" -Path "TestDrive:\"
-         Mock Get-ChildItem { @{Name = "test4.scriptmodule.ps1"; FullName = "TestDrive:\test4.scriptmodule.ps1" } } -ParameterFilter { $Filter -eq "*.scriptmodule.ps1" }
+         Mock Get-ChildItem { @{Name = "test4.scriptmodule.ps1"; FullName = "TestDrive:\test4.scriptmodule.ps1"; BaseName = "test4.steptemplate"  } } -ParameterFilter { $Filter -eq "*.scriptmodule.ps1" }
          
          { Invoke-TeamCityCiUpload -Path "TestDrive:\" -BuildDirectory "TestDrive:\.BuildOutput" -ProcessingMode Individual } | Should Not Throw
      }


### PR DESCRIPTION
A bug was introduced in 8a287e2815e1b945c16ec846fdb0b666d547e079 which causes a Pester test to fail.
The failing test is: Invoke-TeamCityCiUpload.Should handle only a single file being returned from Get-ChildItem in individual mode

It is due to the change in the PR #18 making use of the 'BaseLine' property from Get-ChildItem results, which the mocked Get-ChildItem in the Pester tests didn't contain.

Bug was introduced in the following change:
<img width="679" alt="bug introduction" src="https://cloud.githubusercontent.com/assets/1769405/15149545/d18bfa56-16c1-11e6-830e-90a1f01991f2.png">

Build & deploy of the module, and test run of step template import showing it functioning end-to-end
<img width="1085" alt="bug fix" src="https://cloud.githubusercontent.com/assets/1769405/15149265/c1abef2a-16c0-11e6-9ae0-cf2df0d911ad.png">