### PR TITLE
Removing spaces from psd1's tag metadata

### DIFF
--- a/OctopusStepTemplateCi/OctopusStepTemplateCi.psd1
+++ b/OctopusStepTemplateCi/OctopusStepTemplateCi.psd1
@@ -115,7 +115,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = @('powershell', 'octopus deploy', 'unit testing', 'tdd')
+        Tags = @('powershell', 'octopus-deploy', 'unit-testing', 'tdd')
 
         # A URL to the license for this module.
         LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0.html'


### PR DESCRIPTION
Causes a bug while publishing with PowerShellGet:
Publish-PSArtifactUtility : Failed to publish module 'OctopusStepTemplateCi'
'Failed to process request. 'A nuget package's Tags property extracted from the PowerShell manifest may not contain spaces: 'octopus deploy, unit testing'.'.
The remote server returned an error: (500) Internal Server Error.