### PR TITLE
Altered the removal of the Id parameter key. Now removing all paramet…

### DIFF
--- a/OctopusStepTemplateCi/Cmdlets/Interface/Sync-StepTemplate.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Interface/Sync-StepTemplate.ps1
@@ -64,12 +64,21 @@ function Sync-StepTemplate {
             $newParameter
         })
 
-        $paramCount = ($stepTemplate.Parameters.Count) - 1
-        # Remove the Id from each parameter
-        while ($paramCount -ge 0) {
-            ($stepTemplate.Parameters[$paramCount]).Remove('Id')
-            $paramCount = $paramCount - 1
-        }       
+        # Strip out unneccessary keys such as Id and links.
+        Try {
+            $keysToRemove = $stepTemplate.Parameters.Keys | Select -Unique | ? {$_ -notin ("DefaultValue", "Label", "HelpText", "Name", "DisplaySettings")}
+
+            foreach ($key in $keysToRemove) {
+                $paramCount = ($stepTemplate.Parameters.Count) - 1
+                while ($paramCount -ge 0) {
+                    ($stepTemplate.Parameters[$paramCount]).Remove($key)
+                    $paramCount = $paramCount - 1
+                }
+            }
+        }
+        Catch {
+            Write-Verbose "No parameter keys to remove"
+        }      
 
         if (Compare-StepTemplate -OldTemplate $stepTemplate -NewTemplate $newStepTemplate) {
             Write-TeamCityMessage "Script template '$templateName' has changed. Updating"


### PR DESCRIPTION
…er keys not in a specified list. An additional key has been added in the API for links which causes the cmdlet to think the step has always changed. This copes with the issue with the links key and will prevent this happening in the future if other keys are added. In order to have the other keys update in the future though it would be necessary to add them to the list to be checked.