### PR TITLE
Fix issue with large API response objects on earlier versions of PowerShell

### DIFF
--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Invoke-OctopusOperation.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Invoke-OctopusOperation.Tests.ps1
@@ -29,9 +29,11 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\Test-OctopusConnectivity.ps1"
 . "$here\Convert-ToOctopusJson.ps1"
 . "$here\Get-Cache.ps1"
+. "$here\..\PowerShellManipulation\ParseJson.ps1"
 
 Describe "Invoke-OctopusOperation" {
     Mock Invoke-WebRequest {}
+    Mock ParseJsonString {}
     $Env:OctopusUri = "http://example.local"
     $Env:OctopusApiKey = "secret"
     Mock Get-Cache { @{} }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Invoke-OctopusOperation.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Invoke-OctopusOperation.ps1
@@ -66,7 +66,7 @@ function Invoke-OctopusOperation {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType] "Ssl3, Tls, Tls11, Tls12"
 
     $result = Invoke-WebRequest -Uri $uri -Method $method -Body $jsonObject -Headers @{"X-Octopus-ApiKey" = $OctopusApiKey} -UseBasicParsing |  `
-        % Content | ConvertFrom-Json
+        % Content | ParseJsonString
         
     if ($UseCache) {
         $cache.Add($cacheKey, $result)

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.Tests.ps1
@@ -1,0 +1,90 @@
+<#
+Copyright 2016 ASOS.com Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+<#
+.NAME
+	ParseJson.Tests
+
+.SYNOPSIS
+	Pester tests for ParseJson
+#>
+Set-StrictMode -Version Latest
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
+
+$jsonObjectTestData = @"
+{
+    "foo": {
+        "bar": "foobar"
+    }
+}
+"@
+
+$jsonArrayTestData = @"
+[
+    {
+        "foo": {
+            "bar": "foobar"
+        }
+    },
+    {
+        "bar": {
+            "foo": "barfoo"
+        }
+    }
+]
+"@
+
+Describe "ParseJson" {
+    Context "When not using the pipeline" {
+        $res_obj = ParseJsonString -json $jsonObjectTestData
+
+        It "should return a PSObject" {
+            $res_obj | Should BeOfType PSCustomObject
+        }
+
+        It "should handle a JSON Object document" {
+            ($res_obj | Get-Member).Name -icontains 'foo' | Should Be $true
+            $res_obj.foo.bar | Should Be 'foobar'
+        }
+
+        It "should handle a JSON Array document" {
+            $res_arr = ParseJsonString -json $jsonArrayTestData
+            $res_arr.Count | Should Be 2
+            ($res_arr[1] | Get-Member).Name -icontains 'bar' | Should Be $true
+            $res_arr[1].bar.foo | Should Be 'barfoo'
+        }
+    }
+    
+    Context "When using the pipeline" {
+        It "should return a PSObject" {
+            $jsonObjectTestData | ParseJsonString | Should BeOfType PSCustomObject
+        }
+
+        It "should handle a JSON Object document" {
+            ($jsonObjectTestData | ParseJsonString | Get-Member).Name -icontains 'foo' | Should Be $true
+            ($jsonObjectTestData | ParseJsonString).foo.bar | Should Be 'foobar'
+        }
+
+        It "should handle a JSON Array document" {
+            ($jsonArrayTestData | ParseJsonString).Count | Should Be 2
+            (($jsonArrayTestData | ParseJsonString)[1] | Get-Member).Name -icontains 'bar' | Should Be $true
+            ($jsonArrayTestData | ParseJsonString)[1].bar.foo | Should Be 'barfoo'
+        }
+    }
+}

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.ps1
@@ -69,7 +69,7 @@ function ParseJsonString
     }
 
     # .NET JSON Serializer
-    [System.Reflection.Assembly]::LoadWithPartialName("System.Web.Extensions")
+    [System.Reflection.Assembly]::LoadWithPartialName("System.Web.Extensions") | Out-Null
     $script:javaScriptSerializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
     $script:javaScriptSerializer.MaxJsonLength = [System.Int32]::MaxValue
     $script:javaScriptSerializer.RecursionLimit = 99

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.ps1
@@ -68,7 +68,8 @@ function ParseJsonString
         return $result
     }
 
-    # .NET JSON Serializer 
+    # .NET JSON Serializer
+    [System.Reflection.Assembly]::LoadWithPartialName("System.Web.Extensions")
     $script:javaScriptSerializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
     $script:javaScriptSerializer.MaxJsonLength = [System.Int32]::MaxValue
     $script:javaScriptSerializer.RecursionLimit = 99

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/ParseJson.ps1
@@ -1,0 +1,78 @@
+<#
+Copyright 2016 ASOS.com Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+<#
+.NAME
+	ParseJson.Tests
+
+.SYNOPSIS
+	Uses .NET JSON serializer to deseralize a JSON string, as an alternaive to
+    ConvertFrom-JSON which has different size constraints on various versions of
+    PowerShell.
+#>
+function ParseJsonString
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $json
+    )
+
+    # Internalised functions necessary to parse JSON output from .NET serializer to PowerShell Objects
+    function ParseItem($jsonItem) {
+        if($jsonItem.PSObject.TypeNames -match "Array") {
+            return ParseJsonArray($jsonItem)
+        }
+        elseif($jsonItem.PSObject.TypeNames -match "Dictionary") {
+            return ParseJsonObject([HashTable]$jsonItem)
+        }
+        else {
+            return $jsonItem
+        }
+    }
+
+    function ParseJsonObject($jsonObj) {
+        $result = New-Object -TypeName PSCustomObject
+        foreach ($key in $jsonObj.Keys) {
+            $item = $jsonObj[$key]
+            if ($item) {
+                    $parsedItem = ParseItem $item
+            } else {
+                    $parsedItem = $null
+            }
+            $result | Add-Member -MemberType NoteProperty -Name $key -Value $parsedItem
+        }
+        return $result
+    }
+
+    function ParseJsonArray($jsonArray) {
+        $result = @()
+        $jsonArray | ForEach-Object {
+            $result += , (ParseItem $_)
+        }
+        return $result
+    }
+
+    # .NET JSON Serializer 
+    $script:javaScriptSerializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
+    $script:javaScriptSerializer.MaxJsonLength = [System.Int32]::MaxValue
+    $script:javaScriptSerializer.RecursionLimit = 99
+
+    $config = $javaScriptSerializer.DeserializeObject($json)
+    return ParseItem($config)
+}

--- a/OctopusStepTemplateCi/OctopusStepTemplateCi.psm1
+++ b/OctopusStepTemplateCi/OctopusStepTemplateCi.psm1
@@ -49,6 +49,7 @@ Set-StrictMode -Version Latest
 . "$(Join-Path $PSScriptRoot '\Cmdlets\Internal\PowerShellManipulation\Get-ScriptBody.ps1')"
 . "$(Join-Path $PSScriptRoot '\Cmdlets\Internal\PowerShellManipulation\Get-VariableFromScriptFile.ps1')"
 . "$(Join-Path $PSScriptRoot '\Cmdlets\Internal\PowerShellManipulation\Get-VariableStatement.ps1')"
+. "$(Join-Path $PSScriptRoot '\Cmdlets\Internal\PowerShellManipulation\ParseJson.ps1')"
 . "$(Join-Path $PSScriptRoot '\Cmdlets\Internal\TeamCity\Reset-BuildOutputDirectory.ps1')"
 . "$(Join-Path $PSScriptRoot '\Cmdlets\Internal\TeamCity\Write-TeamCityMessage.ps1')"
 . "$(Join-Path $PSScriptRoot '\Cmdlets\Internal\Tests\Get-ScriptValidationTestsPath.ps1')"


### PR DESCRIPTION
Fixes #28

With the caching implementation used in `Invoke-OctopusOperation` changing the serialization method seemed like a less invasive solution compared to utilising API paging.

 