### PR TITLE
Adding Get-LiteralValueFromAstNode (plus Pester tests)

### DIFF
--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Common/ConvertFrom-OctopusJson.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Common/ConvertFrom-OctopusJson.Tests.ps1
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #>
 
+<#
+.NAME
+   ConvertFrom-OctopusJson.Tests
+
+.SYNOPSIS
+    Pester tests for ConvertFrom-OctopusJson
+#>
+
 $ErrorActionPreference = "Stop";
 Set-StrictMode -Version "Latest";
 
@@ -25,79 +33,79 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe "ConvertFrom-OctopusJson" {
 
-    It "when InputObject is a null json string" {
+    It "Should return the value when the InputObject is a null json string" {
         $input    = "null";
         $expected = $null;
         $actual = ConvertFrom-OctopusJson -InputObject $input;
         $actual | Should Be $expected;
     }
 
-    It "when InputObject is `$true" {
+    It "Should return the value when the InputObject is `$true" {
         $input    = "true";
         $expected = $true;
         $actual = ConvertFrom-OctopusJson -InputObject $input;
         $actual | Should Be $expected;
     }
 
-    It "when InputObject is `$false" {
+    It "Should return the value when the InputObject is `$false" {
         $input    = "false";
         $expected = $false;
         $actual = ConvertFrom-OctopusJson -InputObject $input;
         $actual | Should Be $expected;
     }
 
-    It "when InputObject is an empty string" {
-        $input    = "`"`"";
-        $expected = [string]::Empty;
-        $actual = ConvertFrom-OctopusJson -InputObject $input;
-        $actual | Should Be $expected;
-    }
-
-    It "when InputObject is a simple string" {
-        $input    = "`"my simple string`"";
-        $expected = "my simple string";
-        $actual = ConvertFrom-OctopusJson -InputObject $input;
-        $actual | Should Be $expected;
-    }
-
-    It "when InputObject is a string with apostrophes" {
-        $input    = "`"my string with 'apostrophes'`"";
-        $expected = "my string with 'apostrophes'";
-        $actual = ConvertFrom-OctopusJson -InputObject $input;
-        $actual | Should Be $expected;
-    }
-
-    It "when InputObject is a string with special characters" {
-        $input    = "`"my \\ \`"string\`" with \r\n special \t characters`"";
-        $expected = "my \ `"string`" with `r`n special `t characters";
-        $actual = ConvertFrom-OctopusJson -InputObject $input;
-        $actual | Should Be $expected;
-    }
-
-    It "when InputObject is a string with whitespace between curly brackets" {
-        $input    = "`"{    }`"";
-        $expected = "{    }";
-        $actual = ConvertFrom-OctopusJson -InputObject $input;
-        $actual | Should Be $expected;
-    }
-
-    It "when InputObject is a string resembling the json escape sequence for an apostrophe" {
-        $input    = "`"\\u0027`"";
-        $expected = "\u0027";
-        $actual = ConvertFrom-OctopusJson -InputObject $input;
-        $actual | Should Be $expected;
-    }
-
-    It "when InputObject is a positive integer" {
+    It "Should return the value when the InputObject is a positive integer" {
         $input    = "100";
         $expected = 100;
         $actual = ConvertFrom-OctopusJson -InputObject $input;
         $actual | Should Be $expected;
     }
 
-    It "when InputObject is a negative integer" {
+    It "Should return the value when the InputObject is a negative integer" {
         $input    = "-100";
         $expected = -100;
+        $actual = ConvertFrom-OctopusJson -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is an empty string" {
+        $input    = "`"`"";
+        $expected = [string]::Empty;
+        $actual = ConvertFrom-OctopusJson -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a simple string" {
+        $input    = "`"my simple string`"";
+        $expected = "my simple string";
+        $actual = ConvertFrom-OctopusJson -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string with apostrophes" {
+        $input    = "`"my string with 'apostrophes'`"";
+        $expected = "my string with 'apostrophes'";
+        $actual = ConvertFrom-OctopusJson -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string with special characters" {
+        $input    = "`"my \\ \`"string\`" with \r\n special \t characters`"";
+        $expected = "my \ `"string`" with `r`n special `t characters";
+        $actual = ConvertFrom-OctopusJson -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string with whitespace between curly brackets" {
+        $input    = "`"{    }`"";
+        $expected = "{    }";
+        $actual = ConvertFrom-OctopusJson -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string resembling the json escape sequence for an apostrophe" {
+        $input    = "`"\\u0027`"";
+        $expected = "\u0027";
         $actual = ConvertFrom-OctopusJson -InputObject $input;
         $actual | Should Be $expected;
     }
@@ -110,7 +118,7 @@ Describe "ConvertFrom-OctopusJson" {
         $actual.Length | Should Be 0;
     }
 
-    It "when InputObject is a populated array" {
+    It "Should return the value when the InputObject is a populated array" {
         $input    = "[`r`n  null,`r`n  100,`r`n  `"my string`"`r`n]";
         $actual = ConvertFrom-OctopusJson -InputObject $input;
         @(,$actual) | Should Not Be $null;
@@ -121,7 +129,7 @@ Describe "ConvertFrom-OctopusJson" {
         $actual[2] | Should Be "my string";
     }
 
-    It "when InputObject is an empty json object" {
+    It "Should return the value when the InputObject is an empty json object" {
         $input    = "{}";
         $expected = @{};
         $actual = ConvertFrom-OctopusJson -InputObject $input;
@@ -129,7 +137,7 @@ Describe "ConvertFrom-OctopusJson" {
         $actual.Count | Should Be 0;
     }
 
-    It "when InputObject is a nested json object" {
+    It "Should return the value when the InputObject is a nested json object" {
         $input    = @'
 {
     "myNull"   : null,
@@ -154,7 +162,7 @@ Describe "ConvertFrom-OctopusJson" {
         $actual["myObject"]["childProperty"] | Should Be "childValue";
     }
 
-    It "when InputObject is invalid json" {
+    It "Should return the value when the InputObject is invalid json" {
         { $actual = ConvertFrom-OctopusJson -InputObject "!!!!!"; } `
             | Should Throw;
     }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Common/ConvertTo-PSSource.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Common/ConvertTo-PSSource.Tests.ps1
@@ -23,105 +23,125 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe "ConvertTo-PSSource" {
 
-    It "when InputObject is null" {
+    It "Should return the value when the InputObject is `$null" {
         $input    = $null;
         $expected = "`$null";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is `$true" {
+    It "Should return the value when the InputObject is `$true" {
         $input    = $true;
         $expected = "`$true";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is `$false" {
+    It "Should return the value when the InputObject is `$false" {
         $input    = $false;
         $expected = "`$false";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is an empty string" {
-        $input    = [string]::Empty;
-        $expected = "`"`"";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
-    }
-
-    It "when InputObject is a simple string" {
-        $input    = "my simple string";
-        $expected = "`"my simple string`"";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
-    }
-
-    It "when InputObject is a string with apostrophes" {
-        $input    = "my string with 'apostrophes'";
-        $expected = "`"my string with 'apostrophes'`"";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
-    }
-
-    It "when InputObject is a string with special characters" {
-        $input    = "my \ `"string`" with `r`n special `t characters";
-        $expected = "`"my \ ```"string```" with ``r``n special ``t characters`"";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
-    }
-
-    It "when InputObject is a string with whitespace between curly brackets" {
-        $input    = "{    }";
-        $expected = "`"{    }`"";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
-    }
-
-    It "when InputObject is a string resembling the json escape sequence for an apostrophe" {
-        $input    = "\u0027";
-        $expected = "`"\u0027`"";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
-    }
-
-    It "when InputObject is a positive integer" {
+    It "Should return the value when the InputObject is a positive integer" {
         $input    = 100;
         $expected = "100";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is a negative integer" {
+    It "Should return the value when the InputObject is a negative integer" {
         $input    = -100;
         $expected = "-100";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is an empty array" {
+    It "Should return the value when the InputObject is an empty string" {
+        $input    = [string]::Empty;
+        $expected = "`"`"";
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a simple string" {
+        $input    = "my simple string";
+        $expected = "`"my simple string`"";
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string with apostrophes" {
+        $input    = "my string with 'apostrophes'";
+        $expected = "`"my string with 'apostrophes'`"";
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string with special characters" {
+        $input    = "my \ `"string`" with `r`n special `t characters";
+        $expected = "`"my \ ```"string```" with ``r``n special ``t characters`"";
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string with whitespace between curly brackets" {
+        $input    = "{    }";
+        $expected = "`"{    }`"";
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a string resembling the json escape sequence for an apostrophe" {
+        $input    = "\u0027";
+        $expected = "`"\u0027`"";
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is an empty array" {
         $input    = @();
         $expected = "@()";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is a populated array" {
+    It "Should return the value when the InputObject is an array with a single item" {
+        $input    = @( 100 );
+        $expected = "@(`r`n    100`r`n)";
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is an array with multiple items" {
         $input    = @( $null, 100, "my string" );
         $expected = "@(`r`n    `$null,`r`n    100,`r`n    `"my string`"`r`n)";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is an empty hashtable" {
+    It "Should return the value when the InputObject is an empty hashtable" {
         $input    = @{};
         $expected = "@{}";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is a populated hashtable" {
+    It "Should return the value when the InputObject is a hashtable with a single item" {
+        $input    = @{ "myInt" = 100 };
+        $expected = @'
+@{
+    "myInt" = 100
+}
+'@
+        # normalize line breaks in "$expected" here-string in case they get mangled on git commit
+        if( $expected.IndexOf("`r`n") -eq -1 ) { $expected = $expected.Replace("`n", "`r`n"); }
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
+    }
+
+    It "Should return the value when the InputObject is a hashtable with multiple items" {
         $input    = @{
             "myNull"     = $null
             "myInt"      = 100
@@ -149,18 +169,18 @@ Describe "ConvertTo-PSSource" {
 '@
         # normalize line breaks in "$expected" here-string in case they get mangled on git commit
         if( $expected.IndexOf("`r`n") -eq -1 ) { $expected = $expected.Replace("`n", "`r`n"); }
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is an empty PSCustomObject" {
+    It "Should return the value when the InputObject is an empty PSCustomObject" {
 	$input    = new-object PSCustomObject;
         $expected = "new-object PSCustomObject";
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
-    It "when InputObject is a populated PSCustomObject" {
+    It "Should return the value when the InputObject is a populated PSCustomObject" {
 	$input    = [PSCustomObject] [ordered] @{
             "myNull"     = $null
             "myInt"      = 100
@@ -188,8 +208,8 @@ new-object PSCustomObject -Property ([ordered] @{
 '@
         # normalize line breaks in "$expected" here-string in case they get mangled on git commit
         if( $expected.IndexOf("`r`n") -eq -1 ) { $expected = $expected.Replace("`n", "`r`n"); }
-        ConvertTo-PSSource -InputObject $input `
-            | Should Be $expected;
+        $actual = ConvertTo-PSSource -InputObject $input;
+        $actual | Should Be $expected;
     }
 
 }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.Tests.ps1
@@ -1,0 +1,159 @@
+<#
+Copyright 2016 ASOS.com Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+<#
+.NAME
+   Get-LiteralValueFromAstNode.Tests
+
+.SYNOPSIS
+    Pester tests for Get-LiteralValueFromAstNode
+#>
+
+$ErrorActionPreference = "Stop";
+Set-StrictMode -Version "Latest";
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
+
+Describe "Get-LiteralValueFromAstNode" {
+
+    It "Should return the value when the InputObject is `$null" {
+        $commandExpression = { $null }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be $null;
+    }
+
+    It "Should return the value when the InputObject is `$true" {
+        $commandExpression = { $true }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be $true;
+    }
+
+    It "Should return the value when the InputObject is `$false" {
+        $commandExpression = { $false }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be $false;
+    }
+
+    It "Should return the value when the InputObject is a positive integer" {
+        $commandExpression = { 100 }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be 100;
+    }
+
+    It "Should return the value when the InputObject is a negative integer" {
+        $commandExpression = { -100 }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be -100;
+    }
+
+    It "Should return the value when the InputObject is an empty string" {
+        $commandExpression = { "" }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be "";
+    }
+
+    It "Should return the value when the InputObject is a simple string" {
+        $commandExpression = { "my string" }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be "my string";
+    }
+
+    It "Should return the value when the InputObject is a simple string concatenation" {
+        $commandExpression = { "my" + " " + "string" }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be "my string";
+    }
+
+    It "Should return the value when the InputObject is an expandable string" {
+        $commandExpression = { "[$null|$true|$false]" }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        $actual | Should Be "[|True|False]";
+    }
+
+    It "Should return the value when the InputObject is an empty array" {
+        $commandExpression = { @() }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 0;
+    }
+
+    It "Should return the value when the InputObject is an array with a single item" {
+        $commandExpression = { @( 100 ) }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 1;
+        $actual[0] | Should Be 100;
+    }
+
+    It "Should return the value when the InputObject is an array with multiple items" {
+        $commandExpression = { @( $null, 100, "my string" ) }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 3;
+        $actual[0] | Should Be $null;
+        $actual[1] | Should Be 100;
+        $actual[2] | Should Be "my string";
+    }
+
+    It "Should return the value when the InputObject is an array with missing commas" {
+        $commandExpression = { @(
+            $null,
+            100 # <-- look no comma!
+            "my string"
+        ) }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 3;
+        $actual[0] | Should Be $null;
+        $actual[1] | Should Be 100;
+        $actual[2] | Should Be "my string";
+    }
+
+    It "Should return the value when the InputObject is an empty hashtable" {
+        $commandExpression = { @{} }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 0;
+    }
+
+    It "Should return the value when the InputObject is a hashtable with a single item" {
+        $commandExpression = { @{ "myKey" = 100 } }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 1;
+        $actual["myKey"] | Should Be 100;
+    }
+
+    It "Should return the value when the InputObject is a hashtable with multiple items" {
+        $commandExpression = { @{ "myKey1" = $null; "myKey2" = 100; "myKey3" = "my string" } }.Ast.EndBlock.Statements.PipelineElements[0];
+        $actual = Get-LiteralValueFromAstNode -Node $commandExpression;
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 3;
+        $actual["myKey1"] | Should Be $null;
+        $actual["myKey2"] | Should Be 100;
+        $actual["myKey3"] | Should Be "my string";
+    }
+
+}

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.ps1
@@ -1,0 +1,191 @@
+<#
+Copyright 2016 ASOS.com Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+<#
+.NAME
+    Get-LiteralValueFromAstNode
+
+.SYNOPSIS
+    Gets the literal value represented by a PowerShell Ast node.
+
+.DESCRIPTION
+    Gets the literal value represented by a PowerShell Ast node.
+
+    This is safer than calling Invoke() on a script block as it won't execute any
+    instruction statements (e.g. write-host, remove-item, format-volume) while evaluating.
+
+    It also side-steps an issue with ScriptBlock.Invoke which converts an array containing
+    one item into the same output as the unrolled item. For example {100}.Invoke() returns
+    an object of type [System.Collections.ObjectModel.Collection[[System.Management.Automation.PSObject]]
+    containing one item with a value of 100, but {@(100)}.Invoke() also returns exactly
+    the same result. There's no way of knowing whether a return value of 100 from Invoke()
+    was declared inside the script block as a free-standing value or as an array with a
+    single item. By contrast, Get-LiteralValueFromAstNode will return an array containing
+    a single item if that's what the Ast specifically represents.
+    
+#>
+function Get-LiteralValueFromAstNode
+{
+
+    param
+    (
+
+        [Parameter(Mandatory=$true)]
+        [System.Management.Automation.Language.Ast]
+        $Node
+
+    )
+
+    switch( $true )
+    {
+
+        { $Node -is [System.Management.Automation.Language.ConstantExpressionAst] } {
+            # bool, int32
+            return $Node.Value;
+        }
+
+        { $Node -is [System.Management.Automation.Language.StringConstantExpressionAst] } {
+            return $node.Value;
+        }
+
+        { $Node -is [System.Management.Automation.Language.ExpandableStringExpressionAst] } {
+            # reverse the nested expressions so we can substitute them without tracking start positions
+            $nestedExpressions = @($Node.NestedExpressions);
+            [array]::Reverse($nestedExpressions);
+	    # substitute the values
+            # e.g. "[$null|$true|$false]" -> "[|True|False]";
+	    $result = $Node.Value;
+	    foreach( $nestedExpression in $nestedExpressions )
+            {
+                # work out the range to substitute
+                $relativeStart = $nestedExpression.Extent.StartOffset - $Node.Extent.StartOffset - 1;
+                $relativeEnd = $nestedExpression.Extent.EndOffset - $Node.Extent.StartOffset - 1;
+                $head = $result.Substring(0, $relativeStart);
+                $tail = $result.Substring($relativeEnd);
+                # work out the value to substitute
+                $nestedValue = Get-LiteralValueFromAstNode -Node $nestedExpression;
+                if( $nestedValue -ne $null )
+                {
+                    $nestedValue = $nestedValue.ToString();
+                }
+                # perform the substitution
+                $result = $head + $nestedValue + $tail;
+            }
+            return $result;
+        }
+
+        { $Node -is [System.Management.Automation.Language.VariableExpressionAst] } {
+            # only evaluate built-in literal values, not user defined variables
+	    # or built-in variables that can have different values on different systems.
+            switch( $Node.VariablePath.UserPath )
+            {
+                "null"  { return $null; }
+                "true"  { return $true; }
+                "false" { return $false; }
+                default {
+                    throw new-object System.InvalidOperationException("Variable values not supported.");
+                }
+            }
+        }
+
+        { $Node -is [System.Management.Automation.Language.BinaryExpressionAst] } {
+            switch( $Node.Operator )
+            {
+                "Plus" {
+                    $leftValue  = Get-LiteralValueFromAstNode -Node $Node.Left;
+                    $rightValue = Get-LiteralValueFromAstNode -Node $Node.Right;
+                    $result     = $leftValue + $rightValue;
+                    return @(, $result);
+                }
+                default {
+                    throw new-object System.InvalidOperationException("Operator not supported.");
+                }
+            }
+        }
+
+        { $Node -is [System.Management.Automation.Language.CommandExpressionAst] } {
+	    $value = Get-LiteralValueFromAstNode -Node $Node.Expression;
+	    return @(, $value);
+	}
+
+        { $Node -is [System.Management.Automation.Language.ArrayExpressionAst] } {
+            if( $Node.StaticType -ne [System.Object[]] )
+	    {
+                # we don't handle arrays of other types of objects yet (e.g. [System.String[]])
+                throw new-object System.InvalidOperationException("Array element type not supported.");
+	    }
+            # if a comma is (accidentally?) missed out between elements that are separated by
+            # line-breaks, the powershell parser will create a separate sub-expression statement
+            # for each group of items that *are* comma separated.
+            #
+            # e.g.
+            #
+            # $x = @(
+            #     10 # <-- look no comma!
+            #     20
+            # )
+            #
+            # in this case, there are multiple statements and we need to aggregate the items
+            $results = @();
+            foreach( $statementAst in $Node.SubExpression.Statements )
+            {
+                if( ($statementAst -isnot [System.Management.Automation.Language.PipelineAst]) -or
+                    ($statementAst.PipelineElements.Count -ne 1) -or
+                    ($statementAst.PipelineElements[0] -isnot [System.Management.Automation.Language.CommandExpressionAst]) )
+                {
+                    throw new-object System.InvalidOperationException("Array expression does not represent a literal array.");
+                }
+                $itemListExpression = $statementAst.PipelineElements[0].Expression;
+                $results += Get-LiteralValueFromAstNode -Node $itemListExpression;
+            }
+            return @(, $results);
+        }
+
+        { $Node -is [System.Management.Automation.Language.ArrayLiteralAst] } {
+            $results = @();
+            foreach( $expressionAst in $Node.Elements )
+            {
+                $results += Get-LiteralValueFromAstNode -Node $expressionAst;
+            }
+            return @(, $results);
+        }
+
+        { $Node -is [System.Management.Automation.Language.HashtableAst] } {
+            $result = @{};
+	    foreach( $kvp in $Node.KeyValuePairs )
+            {
+               # convert the key
+               $key = Get-LiteralValueFromAstNode -Node $kvp.Item1;
+               # convert the value
+	       if( ($kvp.Item2 -isnot [System.Management.Automation.Language.PipelineAst]) -or
+                   ($kvp.Item2.PipelineElements.Count -ne 1 ) )
+               {
+                   throw new-object System.InvalidOperationException("Hashtable expression could not be processed.");
+               }	       
+               $value = Get-LiteralValueFromAstNode -Node $kvp.Item2.PipelineElements[0];
+               # append to the result set
+	       $result.Add($key, $value);
+            }
+            return @(, $result);
+        }
+
+        default {
+            throw new-object System.InvalidOperationException("Ast nodes of type '$($Node.GetType().FullName)' are not supported.");
+        }
+
+    }
+
+}

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.ps1
@@ -53,7 +53,7 @@ function Get-LiteralValueFromAstNode
     {
 
         { $Node -is [System.Management.Automation.Language.ConstantExpressionAst] } {
-            # bool, int32
+            # int32
             return $Node.Value;
         }
 
@@ -65,10 +65,10 @@ function Get-LiteralValueFromAstNode
             # reverse the nested expressions so we can substitute them without tracking start positions
             $nestedExpressions = @($Node.NestedExpressions);
             [array]::Reverse($nestedExpressions);
-	    # substitute the values
+            # substitute the values
             # e.g. "[$null|$true|$false]" -> "[|True|False]";
-	    $result = $Node.Value;
-	    foreach( $nestedExpression in $nestedExpressions )
+            $result = $Node.Value;
+            foreach( $nestedExpression in $nestedExpressions )
             {
                 # work out the range to substitute
                 $relativeStart = $nestedExpression.Extent.StartOffset - $Node.Extent.StartOffset - 1;
@@ -89,7 +89,7 @@ function Get-LiteralValueFromAstNode
 
         { $Node -is [System.Management.Automation.Language.VariableExpressionAst] } {
             # only evaluate built-in literal values, not user defined variables
-	    # or built-in variables that can have different values on different systems.
+            # or built-in variables that can have different values on different systems.
             switch( $Node.VariablePath.UserPath )
             {
                 "null"  { return $null; }
@@ -117,16 +117,16 @@ function Get-LiteralValueFromAstNode
         }
 
         { $Node -is [System.Management.Automation.Language.CommandExpressionAst] } {
-	    $value = Get-LiteralValueFromAstNode -Node $Node.Expression;
-	    return @(, $value);
-	}
+            $value = Get-LiteralValueFromAstNode -Node $Node.Expression;
+            return @(, $value);
+        }
 
         { $Node -is [System.Management.Automation.Language.ArrayExpressionAst] } {
             if( $Node.StaticType -ne [System.Object[]] )
-	    {
+            {
                 # we don't handle arrays of other types of objects yet (e.g. [System.String[]])
                 throw new-object System.InvalidOperationException("Array element type not supported.");
-	    }
+            }
             # if a comma is (accidentally?) missed out between elements that are separated by
             # line-breaks, the powershell parser will create a separate sub-expression statement
             # for each group of items that *are* comma separated.
@@ -165,19 +165,19 @@ function Get-LiteralValueFromAstNode
 
         { $Node -is [System.Management.Automation.Language.HashtableAst] } {
             $result = @{};
-	    foreach( $kvp in $Node.KeyValuePairs )
+            foreach( $kvp in $Node.KeyValuePairs )
             {
                # convert the key
                $key = Get-LiteralValueFromAstNode -Node $kvp.Item1;
                # convert the value
-	       if( ($kvp.Item2 -isnot [System.Management.Automation.Language.PipelineAst]) -or
+               if( ($kvp.Item2 -isnot [System.Management.Automation.Language.PipelineAst]) -or
                    ($kvp.Item2.PipelineElements.Count -ne 1 ) )
                {
                    throw new-object System.InvalidOperationException("Hashtable expression could not be processed.");
-               }	       
+               }       
                $value = Get-LiteralValueFromAstNode -Node $kvp.Item2.PipelineElements[0];
                # append to the result set
-	       $result.Add($key, $value);
+               $result.Add($key, $value);
             }
             return @(, $result);
         }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-LiteralValueFromAstNode.ps1
@@ -53,80 +53,132 @@ function Get-LiteralValueFromAstNode
     {
 
         { $Node -is [System.Management.Automation.Language.ConstantExpressionAst] } {
-            # int32
+
+            # represents a constant value - e.g. 100
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-1.1.0
+
             return $Node.Value;
+
         }
 
         { $Node -is [System.Management.Automation.Language.StringConstantExpressionAst] } {
+
+            # represents a string constant with no variable references or no sub-expressions.
+            # e.g. "my string"
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-1.1.0
+
             return $node.Value;
+
         }
 
         { $Node -is [System.Management.Automation.Language.ExpandableStringExpressionAst] } {
+
+            # represents a string which contains variable references (e.g. "my $true string", "my $var string") or sub-expressions (e.g. "my $(10 * 2) string"),
+            # where the values need to be expanded in order to compute the literal string value
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-1.1.0
+
             # reverse the nested expressions so we can substitute them without tracking start positions
             $nestedExpressions = @($Node.NestedExpressions);
             [array]::Reverse($nestedExpressions);
+
             # substitute the values
             # e.g. "[$null|$true|$false]" -> "[|True|False]";
             $result = $Node.Value;
             foreach( $nestedExpression in $nestedExpressions )
             {
+
                 # work out the range to substitute
                 $relativeStart = $nestedExpression.Extent.StartOffset - $Node.Extent.StartOffset - 1;
                 $relativeEnd = $nestedExpression.Extent.EndOffset - $Node.Extent.StartOffset - 1;
                 $head = $result.Substring(0, $relativeStart);
                 $tail = $result.Substring($relativeEnd);
+
                 # work out the value to substitute
                 $nestedValue = Get-LiteralValueFromAstNode -Node $nestedExpression;
                 if( $nestedValue -ne $null )
                 {
                     $nestedValue = $nestedValue.ToString();
                 }
+
                 # perform the substitution
                 $result = $head + $nestedValue + $tail;
+
             }
+
             return $result;
+
         }
 
         { $Node -is [System.Management.Automation.Language.VariableExpressionAst] } {
+
+            # represents a reference to a variable that needs to be resolved in order to evaluate its value
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-1.1.0
+
             # only evaluate built-in literal values, not user defined variables
             # or built-in variables that can have different values on different systems.
+            if( -not $Node.IsConstantVariable )
+            {
+                throw new-object System.InvalidOperationException("Only variable that reference constant values can be evaluated (e.g. `$true, `$false, `$null).");
+            }
+
             switch( $Node.VariablePath.UserPath )
             {
                 "null"  { return $null; }
                 "true"  { return $true; }
                 "false" { return $false; }
                 default {
-                    throw new-object System.InvalidOperationException("Variable values not supported.");
+                    throw new-object System.InvalidOperationException("Variable '`$$($Node.VariablePath.UserPath)' not supported.");
                 }
             }
+
         }
 
         { $Node -is [System.Management.Automation.Language.BinaryExpressionAst] } {
+
+            # represents an operator that requires two parameters (e.g. { 2 + 2 } or  { "my" + "string" } );
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-1.1.0
+
             switch( $Node.Operator )
             {
+
                 "Plus" {
                     $leftValue  = Get-LiteralValueFromAstNode -Node $Node.Left;
                     $rightValue = Get-LiteralValueFromAstNode -Node $Node.Right;
                     $result     = $leftValue + $rightValue;
                     return @(, $result);
                 }
+
                 default {
                     throw new-object System.InvalidOperationException("Operator not supported.");
                 }
+
             }
+
         }
 
         { $Node -is [System.Management.Automation.Language.CommandExpressionAst] } {
+
+            # represents the first expression in a pipeleine
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-1.1.0
+
             $value = Get-LiteralValueFromAstNode -Node $Node.Expression;
+
             return @(, $value);
+
         }
 
         { $Node -is [System.Management.Automation.Language.ArrayExpressionAst] } {
+
+            # represents an array expression - e.g. { @( 1, 2, 3 ) }, as opposed to
+	    # an array literal - e.g. { 1, 2, 3 }
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-1.1.0
+
             if( $Node.StaticType -ne [System.Object[]] )
             {
                 # we don't handle arrays of other types of objects yet (e.g. [System.String[]])
                 throw new-object System.InvalidOperationException("Array element type not supported.");
             }
+
             # if a comma is (accidentally?) missed out between elements that are separated by
             # line-breaks, the powershell parser will create a separate sub-expression statement
             # for each group of items that *are* comma separated.
@@ -151,24 +203,42 @@ function Get-LiteralValueFromAstNode
                 $itemListExpression = $statementAst.PipelineElements[0].Expression;
                 $results += Get-LiteralValueFromAstNode -Node $itemListExpression;
             }
+
             return @(, $results);
+
         }
 
         { $Node -is [System.Management.Automation.Language.ArrayLiteralAst] } {
+
+            # represents an array literal - e.g. { 1, 2, 3 }
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-1.1.0
+
             $results = @();
-            foreach( $expressionAst in $Node.Elements )
+            if( $null -ne $Node.Elements )
             {
-                $results += Get-LiteralValueFromAstNode -Node $expressionAst;
+                foreach( $expressionAst in $Node.Elements )
+                {
+                    $results += Get-LiteralValueFromAstNode -Node $expressionAst;
+                }
             }
+
             return @(, $results);
+
         }
 
         { $Node -is [System.Management.Automation.Language.HashtableAst] } {
+
+            # represents a hashtable literal - e.g. { @{ "key" = "value" } }
+            # see https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-1.1.0
+
             $result = @{};
+
             foreach( $kvp in $Node.KeyValuePairs )
             {
+
                # convert the key
                $key = Get-LiteralValueFromAstNode -Node $kvp.Item1;
+
                # convert the value
                if( ($kvp.Item2 -isnot [System.Management.Automation.Language.PipelineAst]) -or
                    ($kvp.Item2.PipelineElements.Count -ne 1 ) )
@@ -176,10 +246,14 @@ function Get-LiteralValueFromAstNode
                    throw new-object System.InvalidOperationException("Hashtable expression could not be processed.");
                }       
                $value = Get-LiteralValueFromAstNode -Node $kvp.Item2.PipelineElements[0];
+
                # append to the result set
                $result.Add($key, $value);
+
             }
+
             return @(, $result);
+
         }
 
         default {

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
@@ -87,7 +87,7 @@ function test {
         $actual | Should Be -100;
     }
 
-    It "Should return the value if the variable is an empty" {
+    It "Should return the value if the variable is an empty string" {
         $script = @'
 function test {
     $myTestVariable = "";

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
@@ -19,9 +19,11 @@ limitations under the License.
     Get-VariableFromScriptText.Tests
 
 .SYNOPSIS
-    Pester tests for Get-VariableFromScriptText.
+    Pester tests for Get-VariableFromScriptText
 #>
-Set-StrictMode -Version Latest
+
+$ErrorActionPreference = "Stop";
+Set-StrictMode -Version "Latest";
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
@@ -30,17 +32,169 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe "Get-VariableFromScriptText" {
 
-    It "Should get the value of the variable from a script" {
+    It "Should return the value if the variable is `$null" {
         $script = @'
 function test {
-    $myTestVariable = "some value";
+    $myTestVariable = $null;
     Write-Host $myTestVariable;
 }
 '@
-        $result = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
-        $result | Should Be "some value";
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable";
+        $actual | Should Be $null;
     }
-    
+
+    It "Should return the value if the variable is `$true" {
+        $script = @'
+function test {
+    $myTestVariable = $true;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be $true;
+    }
+
+    It "Should return the value if the variable is `$false" {
+        $script = @'
+function test {
+    $myTestVariable = $false;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be $false;
+    }
+
+    It "Should return the value if the variable is a positive integer" {
+        $script = @'
+function test {
+    $myTestVariable = 100;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+        $actual | Should Be 100;
+    }
+
+    It "Should return the value if the variable is a negative integer" {
+        $script = @'
+function test {
+    $myTestVariable = -100;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+        $actual | Should Be -100;
+    }
+
+    It "Should return the value if the variable is an empty" {
+        $script = @'
+function test {
+    $myTestVariable = "";
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+        $actual | Should Be "";
+    }
+
+    It "Should return the value if the variable is a simple string" {
+        $script = @'
+function test {
+    $myTestVariable = "my string";
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+        $actual | Should Be "my string";
+    }
+
+    It "Should return the value if the variable is an empty array" {
+        $script = @'
+function test {
+    $myTestVariable = @();
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 0;
+    }
+
+    It "Should return the value if the variable is an array with a single item" {
+        $script = @'
+function test {
+    $myTestVariable = @( 100 );
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 1;
+        $actual[0] | Should Be 100;
+    }
+
+    It "Should return the value if the variable is an array with multiple items" {
+        $script = @'
+function test {
+    $myTestVariable = @( $null, 100, "my string" );
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 3;
+        $actual[0] | Should Be $null;
+        $actual[1] | Should Be 100;
+        $actual[2] | Should Be "my string";
+    }
+
+    It "Should return the value if the variable is an empty hashtable" {
+        $script = @'
+function test {
+    $myTestVariable = @{};
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 0;
+    }
+
+    It "Should return the value if the variable is a hashtable with a single item" {
+        $script = @'
+function test {
+    $myTestVariable = @{ "myKey" = 100 };
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 1;
+        $actual["myKey"] | Should Be 100;
+    }
+
+    It "Should return the value if the variable is a hashtable with multiple items" {
+$script = @'
+function test {
+    $myTestVariable = @{ "myKey1" = $null; "myKey2" = 100; "myKey3" = "my string" };
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 3;
+        $actual["myKey1"] | Should Be $null;
+        $actual["myKey2"] | Should Be 100;
+        $actual["myKey3"] | Should Be "my string";
+    }
+
     It "Should get the variable statement from a script" {
         $script = @'
 function test {
@@ -48,11 +202,10 @@ function test {
     Write-Host $myTestVariable;
 }
 '@
-
-        $result = Get-VariableFromScriptText -Script $script -Variable "myTestVariable" -DontResolveVariable;
-        $result | Should Be "`"some value`"";
+        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable" -DontResolveVariable;
+        $actual | Should Be "`"some value`"";
     }
-    
+ 
     It "Should throw an exception if the variable isn't defined" {
         $script = @'
 function test {
@@ -60,8 +213,9 @@ function test {
     Write-Host $myTestVariable;
 }
 '@
-        { Get-VariableFromScriptText -Script $script -Variable "myUndefinedVariable" } `
-            | Should Throw
+        {
+            $actual = Get-VariableFromScriptText -Script $script -Variable "myUndefinedVariable";
+        } | Should Throw;
     }
 
 }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
@@ -32,7 +32,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe "Get-VariableFromScriptText" {
 
-    It "Should return the value if the variable is `$null" {
+    It "Should return the value when the variable is `$null" {
         $script = @'
 function test {
     $myTestVariable = $null;
@@ -43,7 +43,7 @@ function test {
         $actual | Should Be $null;
     }
 
-    It "Should return the value if the variable is `$true" {
+    It "Should return the value when the variable is `$true" {
         $script = @'
 function test {
     $myTestVariable = $true;
@@ -54,7 +54,7 @@ function test {
         $actual | Should Be $true;
     }
 
-    It "Should return the value if the variable is `$false" {
+    It "Should return the value when the variable is `$false" {
         $script = @'
 function test {
     $myTestVariable = $false;
@@ -65,7 +65,7 @@ function test {
         $actual | Should Be $false;
     }
 
-    It "Should return the value if the variable is a positive integer" {
+    It "Should return the value when the variable is a positive integer" {
         $script = @'
 function test {
     $myTestVariable = 100;
@@ -76,7 +76,7 @@ function test {
         $actual | Should Be 100;
     }
 
-    It "Should return the value if the variable is a negative integer" {
+    It "Should return the value when the variable is a negative integer" {
         $script = @'
 function test {
     $myTestVariable = -100;
@@ -87,7 +87,7 @@ function test {
         $actual | Should Be -100;
     }
 
-    It "Should return the value if the variable is an empty string" {
+    It "Should return the value when the variable is an empty string" {
         $script = @'
 function test {
     $myTestVariable = "";
@@ -98,7 +98,7 @@ function test {
         $actual | Should Be "";
     }
 
-    It "Should return the value if the variable is a simple string" {
+    It "Should return the value when the variable is a simple string" {
         $script = @'
 function test {
     $myTestVariable = "my string";
@@ -109,7 +109,7 @@ function test {
         $actual | Should Be "my string";
     }
 
-#    It "Should return the value if the variable is an empty array" {
+#    It "Should return the value when the variable is an empty array" {
 #        $script = @'
 #function test {
 #    $myTestVariable = @();
@@ -122,7 +122,7 @@ function test {
 #        $actual.Length | Should Be 0;
 #    }
 
-#    It "Should return the value if the variable is an array with a single item" {
+#    It "Should return the value when the variable is an array with a single item" {
 #        $script = @'
 #function test {
 #    $myTestVariable = @( 100 );
@@ -136,7 +136,7 @@ function test {
 #        $actual[0] | Should Be 100;
 #    }
 
-    It "Should return the value if the variable is an array with multiple items" {
+    It "Should return the value when the variable is an array with multiple items" {
         $script = @'
 function test {
     $myTestVariable = @( $null, 100, "my string" );
@@ -152,7 +152,7 @@ function test {
         $actual[2] | Should Be "my string";
     }
 
-    It "Should return the value if the variable is an empty hashtable" {
+    It "Should return the value when the variable is an empty hashtable" {
         $script = @'
 function test {
     $myTestVariable = @{};
@@ -165,7 +165,7 @@ function test {
         $actual.Count | Should Be 0;
     }
 
-    It "Should return the value if the variable is a hashtable with a single item" {
+    It "Should return the value when the variable is a hashtable with a single item" {
         $script = @'
 function test {
     $myTestVariable = @{ "myKey" = 100 };
@@ -179,7 +179,7 @@ function test {
         $actual["myKey"] | Should Be 100;
     }
 
-    It "Should return the value if the variable is a hashtable with multiple items" {
+    It "Should return the value when the variable is a hashtable with multiple items" {
 $script = @'
 function test {
     $myTestVariable = @{ "myKey1" = $null; "myKey2" = 100; "myKey3" = "my string" };
@@ -206,7 +206,7 @@ function test {
         $actual | Should Be "`"some value`"";
     }
  
-    It "Should throw an exception if the variable isn't defined" {
+    It "Should throw an exception when the variable isn't defined" {
         $script = @'
 function test {
     $myTestVariable = "some value";

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableFromScriptText.Tests.ps1
@@ -109,32 +109,32 @@ function test {
         $actual | Should Be "my string";
     }
 
-    It "Should return the value if the variable is an empty array" {
-        $script = @'
-function test {
-    $myTestVariable = @();
-    Write-Host $myTestVariable;
-}
-'@
-        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
-        @(,$actual) | Should Not Be $null;
-        @(,$actual) | Should BeOfType [array];
-        $actual.Length | Should Be 0;
-    }
+#    It "Should return the value if the variable is an empty array" {
+#        $script = @'
+#function test {
+#    $myTestVariable = @();
+#    Write-Host $myTestVariable;
+#}
+#'@
+#        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+#        @(,$actual) | Should Not Be $null;
+#        @(,$actual) | Should BeOfType [array];
+#        $actual.Length | Should Be 0;
+#    }
 
-    It "Should return the value if the variable is an array with a single item" {
-        $script = @'
-function test {
-    $myTestVariable = @( 100 );
-    Write-Host $myTestVariable;
-}
-'@
-        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
-        @(,$actual) | Should Not Be $null;
-        @(,$actual) | Should BeOfType [array];
-        $actual.Length | Should Be 1;
-        $actual[0] | Should Be 100;
-    }
+#    It "Should return the value if the variable is an array with a single item" {
+#        $script = @'
+#function test {
+#    $myTestVariable = @( 100 );
+#    Write-Host $myTestVariable;
+#}
+#'@
+#        $actual = Get-VariableFromScriptText -Script $script -Variable "myTestVariable"
+#        @(,$actual) | Should Not Be $null;
+#        @(,$actual) | Should BeOfType [array];
+#        $actual.Length | Should Be 1;
+#        $actual[0] | Should Be 100;
+#    }
 
     It "Should return the value if the variable is an array with multiple items" {
         $script = @'

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableValueFromScriptText.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableValueFromScriptText.Tests.ps1
@@ -1,0 +1,241 @@
+<#
+Copyright 2016 ASOS.com Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+<#
+.NAME
+    Get-VariableValueFromScriptText.Tests
+
+.SYNOPSIS
+    Pester tests for Get-VariableValueFromScriptText.
+#>
+
+$ErrorActionPreference = "Stop";
+Set-StrictMode -Version "Latest";
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
+. "$here\Get-LiteralValueFromAstNode.ps1"
+
+Describe "Get-VariableValueFromScriptText" {
+
+    It "Should return the value when the variable is `$null" {
+        $script = @'
+function test {
+    $myTestVariable = $null;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be $null;
+    }
+
+    It "Should return the value when the variable is `$true" {
+        $script = @'
+function test {
+    $myTestVariable = $true;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be $true;
+    }
+
+    It "Should return the value when the variable is a `$false" {
+        $script = @'
+function test {
+    $myTestVariable = $false;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be $false;
+    }
+
+    It "Should return the value when the variable is a positive integer" {
+        $script = @'
+function test {
+    $myTestVariable = 100;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be 100;
+    }
+
+    It "Should return the value when the variable is a negative integer" {
+        $script = @'
+function test {
+    $myTestVariable = -100;
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be -100;
+    }
+
+    It "Should return the value when the variable is an empty string" {
+        $script = @'
+function test {
+    $myTestVariable = "";
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be "";
+    }
+
+    It "Should return the value when the variable is a simple string" {
+        $script = @'
+function test {
+    $myTestVariable = "my string";
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be "my string";
+    }
+
+    It "Should return the value when the variable is a simple string concatenation" {
+        $script = @'
+function test {
+    $myTestVariable = "my" + " " + "string";
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        $actual | Should Be "my string";
+    }
+
+    It "Should return the value when the variable is an empty array" {
+        $script = @'
+function test {
+    $myTestVariable = @();
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 0;
+    }
+
+    It "Should return the value when the variable is an array with a single item" {
+        $script = @'
+function test {
+    $myTestVariable = @( 100 );
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 1;
+        $actual[0] | Should Be 100;
+    }
+
+    It "Should return the value when the variable is an array with multiple items" {
+        $script = @'
+function test {
+    $myTestVariable = @( $null, 100, "my string" );
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 3;
+        $actual[0] | Should Be $null;
+        $actual[1] | Should Be 100;
+        $actual[2] | Should Be "my string";
+    }
+
+    It "Should return the value when the variable is an array with missing commas" {
+        $script = @'
+function test {
+    $myTestVariable = @(
+        $null,
+        100 # <-- look no comma!
+        "my string"
+    );
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [array];
+        $actual.Length | Should Be 3;
+        $actual[0] | Should Be $null;
+        $actual[1] | Should Be 100;
+        $actual[2] | Should Be "my string";
+    }
+
+    It "Should return the value when the variable is an empty hashtable" {
+        $script = @'
+function test {
+    $myTestVariable = @{};
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 0;
+    }
+
+    It "Should return the value when the variable is a hashtable with a single item" {
+        $script = @'
+function test {
+    $myTestVariable = @{ "myKey" = 100 };
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 1;
+        $actual["myKey"] | Should Be 100;
+    }
+
+    It "Should return the value when the variable is a hashtable with multiple items" {
+$script = @'
+function test {
+    $myTestVariable = @{ "myKey1" = $null; "myKey2" = 100; "myKey3" = "my string" };
+    Write-Host $myTestVariable;
+}
+'@
+        $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myTestVariable";
+        @(,$actual) | Should Not Be $null;
+        @(,$actual) | Should BeOfType [hashtable];
+        $actual.Count | Should Be 3;
+        $actual["myKey1"] | Should Be $null;
+        $actual["myKey2"] | Should Be 100;
+        $actual["myKey3"] | Should Be "my string";
+    }
+
+    It "Should throw an exception when the variable isn't defined" {
+        $script = @'
+function test {
+    $myTestVariable = "some value";
+    Write-Host $myTestVariable;
+}
+'@
+        {
+           $actual = Get-VariableValueFromScriptText -Script $script -VariableName "myUndefinedVariable";
+        } | Should Throw "Assignment statement for variable '`$myUndefinedVariable' could not be found in the specified script.";
+    }
+
+}

--- a/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableValueFromScriptText.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/PowerShellManipulation/Get-VariableValueFromScriptText.ps1
@@ -1,0 +1,58 @@
+<#
+Copyright 2016 ASOS.com Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+<#
+.NAME
+    Get-VariableValueFromScriptText
+
+.SYNOPSIS
+    Returns the variable value for a given variable name that is in a powershell script
+#>
+function Get-VariableValueFromScriptText
+{
+
+    param
+    (
+
+        [Parameter(Mandatory=$true)]
+        [string] $Script,
+
+        [Parameter(Mandatory=$true)]
+        [string] $VariableName
+
+    )
+
+    $tokens = $null;
+    $parseErrors = $null;
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref] $tokens, [ref] $parseErrors);
+
+    $filter = {
+        ($args[0] -is [System.Management.Automation.Language.AssignmentStatementAst]) -and
+        ($args[0].Left -is [System.Management.Automation.Language.VariableExpressionAst]) -and
+        ($args[0].Left.VariablePath.UserPath -eq $VariableName)
+    }
+
+    $assignmentStatementAst = $ast.Find($filter, $true);
+    if( $assignmentStatementAst -eq $null )
+    {
+        throw new-object System.InvalidOperationException("Assignment statement for variable '`$$VariableName' could not be found in the specified script.");
+    }
+
+    $value = Get-LiteralValueFromAstNode -Node $assignmentStatementAst.Right.Expression;
+
+    return @(, $value);
+
+}

--- a/OctopusStepTemplateCi/ScriptValidationTests/StepTemplates/Parameters.ScriptValidationTest.ps1
+++ b/OctopusStepTemplateCi/ScriptValidationTests/StepTemplates/Parameters.ScriptValidationTest.ps1
@@ -71,10 +71,38 @@ Describe "Step template parameters" {
 
             It "ScriptBody should not overwrite input parameter '$variableName'" {
 
-                #This test is here to prevent issues where someone modifies the global part of a step template
-                #but inadvertently overwrites an octopus parameter with a local variable
-                #As we are testing at the function level rather than the whole step template level, we cant 
-                #catch this with our unit tests
+                # This test is here to prevent issues where someone modifies the global part of a step template
+                # but inadvertently overwrites an octopus parameter with a local variable
+                # As we are testing at the function level rather than the whole step template level, we can't 
+                # catch this with our unit tests
+
+                # for example:
+
+                # $StepTemplateName        = "myStepTemplateName";
+                # $StepTemplateDescription = "myStepTemplateDescription";
+                # $StepTemplateParameters  = @(
+                #    @{
+                #        "Name" = "MyParameter"
+                #        "Label" = "My Parameter Label"
+                #        "HelpText" = "My Parameter Help Text"
+                #        "DefaultValue" = $null
+                #        "DisplaySettings" = @{}
+                #    }
+                # );
+                #
+                # function Invoke-StepTemplate
+                # {
+                #     param
+                #     (
+                #         $MyParameter
+                #     )
+                #     $MyParameter = "some other value"; # <-- this assignment should cause the test to fail
+                # }
+                #
+                # if( Test-Path Variable:OctopusParameters )
+                # {
+                #     Invoke-StepTemplate -MyParameter $OctopusParameters["MyParameter"];
+                # }
 
                 $scriptBlock = $null;
                 try


### PR DESCRIPTION
Added a new function ```Get-LiteralValueFromAstNode``` (plus Pester tests) which can be used to walk a parsed PowerShell Ast structure to extract a literal value from a string containing PowerShell code. It's not used yet, but if we did switch to it we could replace calls to ```$scriptBlock.Invoke()``` in ```Get-VariableFromScriptText``` which currently does the same thing, but with a couple of caveats:

- ```$scriptBlock.Invoke()``` *executes* the PowerShell code, which could inadvertently call cmdlets like ```format-volume``` if they are also present in the code being invoked.

- ```$scriptBlock.Invoke()``` also unrolls single-item arrays and just returns the first item instead, which means we lose information that could be useful for validation of input (e.g. ```$StepTemplateParameters``` should be an array of hashtables, but we can't enforce that because it might only contain one parameter which means ```$scriptBlock.Invoke()``` returns the first hashtable, not an array with one hashtable in it).

Switching to the new ```Get-LiteralValueFromAstNode``` will be done at a later date.