### PR TITLE
Renamed [Get-Cache -> Get-OctopusApiCache], [Reset-Cache -> Reset-Oct…

### DIFF
--- a/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Invoke-TeamCityCiUpload" {
         Mock Sync-ScriptModule { @{UploadCount = 0} };
         Mock Sync-StepTemplate { @{UploadCount = 0} };
         Mock Test-OctopusApiConnectivity {};
-        Mock Reset-Cache {};
+        Mock Reset-OctopusApiCache {};
         Mock Invoke-OctopusScriptTestSuite { @{ Passed = 1; Failed = 0; Success = $true } };
 
         Context "Parameter validation" {    
@@ -65,7 +65,7 @@ Describe "Invoke-TeamCityCiUpload" {
         }
 
         It "Should reset the cache before beginning" {
-            Mock Reset-Cache {} -Verifiable;
+            Mock Reset-OctopusApiCache {} -Verifiable;
             Invoke-TeamCityCiUpload -Path "TestDrive:\" -BuildDirectory "TestDrive:\.BuildOutput";
             Assert-VerifiableMock;
         }

--- a/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.ps1
@@ -110,7 +110,7 @@ function Invoke-TeamCityCiUpload
 
         Reset-BuildOutputDirectory -Path $BuildDirectory;
 
-        Reset-Cache;
+        Reset-OctopusApiCache;
 
         switch( $ProcessingMode )
         {

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiActionTemplate.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiActionTemplate.Tests.ps1
@@ -65,7 +65,7 @@ InModuleScope "OctopusStepTemplateCi" {
 
             $cache = @{};
 
-            Mock -CommandName "Get-Cache" `
+            Mock -CommandName "Get-OctopusApiCache" `
                  -MockWith { return $cache; } `
                  -Verifiable;
 

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiCache.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiCache.Tests.ps1
@@ -16,13 +16,23 @@ limitations under the License.
 
 <#
 .NAME
-	Reset-Cache
+    Get-OctopusApiCache.Tests
 
 .SYNOPSIS
-    Resets / clears the cache 
+    Pester tests for Get-OctopusApiCache.
 #>
-function Reset-Cache {
-    $cache = Get-Cache
-    
-    $cache.Clear()
+
+$ErrorActionPreference = "Stop";
+Set-StrictMode -Version "Latest";
+
+InModuleScope "OctopusStepTemplateCi" {
+
+    Describe "Get-OctopusApiCache" {
+
+        It "Should return a hashtable that can be used as a cache" {
+            Get-OctopusApiCache | % GetType | % Name | Should Be "hashtable";
+        }
+
+    }
+
 }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiCache.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiCache.ps1
@@ -16,26 +16,24 @@ limitations under the License.
 
 <#
 .NAME
-    Reset-Cache.Tests
+    Get-OctopusApiCache
 
 .SYNOPSIS
-    Pester tests for Reset-Cache.
+    Returns a hashtable that can be used as a cache
 #>
+function Get-OctopusApiCache
+{
 
-$ErrorActionPreference = "Stop";
-Set-StrictMode -Version "Latest";
-
-InModuleScope "OctopusStepTemplateCi" {
-
-    Describe "Reset-Cache" {
-
-        It "Should clear out the cache" {
-            $cache = Get-Cache;
-            $cache.Add("key", "value");
-            Reset-Cache;
-            Get-Cache | % Count | Should BeExactly 0;
-        }
-
+    if( $null -eq $ExecutionContext.SessionState.Module.PrivateData )
+    {
+        $ExecutionContext.SessionState.Module.PrivateData = @{};
     }
+
+    if( $null -eq $ExecutionContext.SessionState.Module.PrivateData["OctopusApiCache"] )
+    {
+        $ExecutionContext.SessionState.Module.PrivateData["OctopusApiCache"] = @{};
+    }
+    
+    return $ExecutionContext.SessionState.Module.PrivateData.OctopusApiCache;
 
 }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiLibraryVariableSet.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiLibraryVariableSet.Tests.ps1
@@ -65,7 +65,7 @@ InModuleScope "OctopusStepTemplateCi" {
 
             $cache = @{};
 
-            Mock -CommandName "Get-Cache" `
+            Mock -CommandName "Get-OctopusApiCache" `
                  -MockWith { return $cache; } `
                  -Verifiable;
 

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiObject.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Get-OctopusApiObject.Tests.ps1
@@ -65,7 +65,7 @@ InModuleScope "OctopusStepTemplateCi" {
 
             $cache = @{};
 
-            Mock -CommandName "Get-Cache" `
+            Mock -CommandName "Get-OctopusApiCache" `
                  -MockWith { return $cache; } `
                  -Verifiable;
 

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Invoke-OctopusApiOperation.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Invoke-OctopusApiOperation.Tests.ps1
@@ -35,7 +35,7 @@ InModuleScope "OctopusStepTemplateCi" {
         Mock -CommandName "Invoke-WebRequest" `
              -MockWith { return @{ "Content" = "" }; };
 
-        Mock -CommandName "Get-Cache" `
+        Mock -CommandName "Get-OctopusApiCache" `
              -MockWith { return @{}; };
 
         It "Should call Test-OctopusApiConnectivity" {
@@ -117,7 +117,7 @@ InModuleScope "OctopusStepTemplateCi" {
 
             $cache = @{};
 
-            Mock -CommandName "Get-Cache" `
+            Mock -CommandName "Get-OctopusApiCache" `
                  -MockWith { return $cache; } `
                  -Verifiable;
 

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Invoke-OctopusApiOperation.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Invoke-OctopusApiOperation.ps1
@@ -53,7 +53,7 @@ function Invoke-OctopusApiOperation
     $Uri      = $OctopusUri + $Uri;
     $cacheKey = "$Uri-$Method";
 
-    $cache = Get-Cache;
+    $cache = Get-OctopusApiCache;
     if( $UseCache -and $cache.ContainsKey($cacheKey) )
     {
         return $cache.Item($cacheKey);
@@ -69,7 +69,7 @@ function Invoke-OctopusApiOperation
     else
     {
         $requestBody = ConvertTo-OctopusJson -InputObject $Body;
-        $response = Invoke-WebRequest -Uri $Uri -Method $method -Body $requestBody -Headers @{ "X-Octopus-ApiKey" = $OctopusApiKey } -UseBasicParsing;
+        $response = Invoke-WebRequest -Uri $Uri -Method $Method -Body $requestBody -Headers @{ "X-Octopus-ApiKey" = $OctopusApiKey } -UseBasicParsing;
     }
 
     $result = ConvertFrom-OctopusJson -InputObject $response.Content;

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Reset-OctopusApiCache.Tests.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Reset-OctopusApiCache.Tests.ps1
@@ -16,10 +16,10 @@ limitations under the License.
 
 <#
 .NAME
-	Get-Cache.Tests
+    Reset-Cache.Tests
 
 .SYNOPSIS
-	Pester tests for Get-Cache.
+    Pester tests for Reset-Cache.
 #>
 
 $ErrorActionPreference = "Stop";
@@ -27,10 +27,17 @@ Set-StrictMode -Version "Latest";
 
 InModuleScope "OctopusStepTemplateCi" {
 
-    Describe "Get-Cache" {
+    Describe "Reset-Cache" {
 
-        It "Should return a hashtable that can be used as a cache" {
-            Get-Cache | % GetType | % Name | Should Be "hashtable";
+        It "Should clear out the cache" {
+
+            $cache = Get-OctopusApiCache;
+            $cache.Add("key", "value");
+
+            Reset-OctopusApiCache;
+
+            (Get-OctopusApiCache).Count | Should BeExactly 0;
+
         }
 
     }

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Reset-OctopusApiCache.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/Reset-OctopusApiCache.ps1
@@ -16,18 +16,16 @@ limitations under the License.
 
 <#
 .NAME
-	Get-Cache
+    Reset-OctopusApiCache
 
 .SYNOPSIS
-    Returns a hashtable that can be used as a cache
+    Resets / clears the cache 
 #>
-function Get-Cache {
-    if ($null -eq $ExecutionContext.SessionState.Module.PrivateData) {
-	   $ExecutionContext.SessionState.Module.PrivateData = @{}
-    }
-    if ($null -eq $ExecutionContext.SessionState.Module.PrivateData['Cache']) {
-        $ExecutionContext.SessionState.Module.PrivateData['Cache'] = @{}
-    }
+function Reset-OctopusApiCache
+{
+
+    $cache = Get-OctopusApiCache;
     
-    return $ExecutionContext.SessionState.Module.PrivateData.Cache
+    $cache.Clear();
+
 }

--- a/OctopusStepTemplateCi/OctopusStepTemplateCi.psd1
+++ b/OctopusStepTemplateCi/OctopusStepTemplateCi.psd1
@@ -94,12 +94,14 @@ NestedModules = @(
 
     <# Internal functions only used within this module #>
     "Cmdlets\Internal\Octopus\Api\Get-OctopusApiActionTemplate.ps1",
+    "Cmdlets\Internal\Octopus\Api\Get-OctopusApiCache.ps1",
     "Cmdlets\Internal\Octopus\Api\Get-OctopusApiLibraryVariableSet.ps1",
     "Cmdlets\Internal\Octopus\Api\Get-OctopusApiObject.ps1",
     "Cmdlets\Internal\Octopus\Api\Invoke-OctopusApiOperation.ps1",
     "Cmdlets\Internal\Octopus\Api\New-OctopusApiActionTemplate.ps1",
     "Cmdlets\Internal\Octopus\Api\New-OctopusApiLibraryVariableSet.ps1",
     "Cmdlets\Internal\Octopus\Api\New-OctopusApiObject.ps1",
+    "Cmdlets\Internal\Octopus\Api\Reset-OctopusApiCache.ps1",
     "Cmdlets\Internal\Octopus\Api\Test-OctopusApiConnectivity.ps1",
     "Cmdlets\Internal\Octopus\Api\Update-OctopusApiActionTemplate.ps1",
     "Cmdlets\Internal\Octopus\Api\Update-OctopusApiLibraryVariableSet.ps1",
@@ -114,8 +116,6 @@ NestedModules = @(
     "Cmdlets\Internal\Octopus\ScriptModules\Read-ScriptModuleVariableSet.ps1",
     "Cmdlets\Internal\Octopus\StepTemplates\Compare-StepTemplate.ps1",
     "Cmdlets\Internal\Octopus\StepTemplates\Read-StepTemplate.ps1",
-    "Cmdlets\Internal\Octopus\Get-Cache.ps1",
-    "Cmdlets\Internal\Octopus\Reset-Cache.ps1",
     "Cmdlets\Internal\PowerShellManipulation\Get-LiteralValueFromAstNode.ps1",
     "Cmdlets\Internal\PowerShellManipulation\Get-ScriptBodyFromScriptText.ps1",
     "Cmdlets\Internal\PowerShellManipulation\Get-VariableFromScriptText.ps1",


### PR DESCRIPTION
Moved and renamed Get-Cache and Reset-Cache so they're under the new "Octopus\Api" subfolder with all the other API stuff, and use similar names (Get-OctopusApiCache, Reset-OctopusApiCache).