### PR TITLE
New-OctopusApi* takes [object] instead of [string]

### DIFF
--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/New-OctopusApiActionTemplate.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/New-OctopusApiActionTemplate.ps1
@@ -34,7 +34,7 @@ function New-OctopusApiActionTemplate
         [string] $OctopusApiKey = $env:OctopusApiKey,
 
         [Parameter(Mandatory=$true)]
-        [string] $Object
+        [object] $Object
 
     )
 

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/New-OctopusApiLibraryVariableSet.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/New-OctopusApiLibraryVariableSet.ps1
@@ -34,7 +34,7 @@ function New-OctopusApiLibraryVariableSet
         [string] $OctopusApiKey = $env:OctopusApiKey,
 
         [Parameter(Mandatory=$true)]
-        [string] $Object
+        [object] $Object
 
     )
 

--- a/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/New-OctopusApiObject.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Internal/Octopus/Api/New-OctopusApiObject.ps1
@@ -37,7 +37,7 @@ function New-OctopusApiObject
         [string] $ObjectUri,
 
         [Parameter(Mandatory=$true)]
-        [string] $Object
+        [object] $Object
 
     )
 


### PR DESCRIPTION
Fixed bug which causes HTTP 500 error when trying to create new objects using the Octopus API.

The problem is that the hashtable gets cast to a string by PowerShell rather than Invoke-OctopusApiOperation, which means the POST sends the literal string '"System.Collection.Hashtable"' rather than the json that the hashtable represents.