### PR TITLE
Added error handling for when Octopus API returns erors

### DIFF
--- a/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Interface/Invoke-TeamCityCiUpload.ps1
@@ -159,7 +159,13 @@ function Invoke-TeamCityCiUpload
                         }
                         elseif( $_.Name -like $StepTemplateFilter )
                         {
-                            Sync-StepTemplate -Path $_.FullName -UseCache;
+                            try
+                            {
+                                Sync-StepTemplate -Path $_.FullName -UseCache;
+                            }
+                            catch
+                            {
+                            }
                         }
                     } | % UploadCount | Measure-Object -Sum | % Sum;
 
@@ -200,4 +206,4 @@ function Invoke-TeamCityCiUpload
 
     }
 
- }
+}

--- a/OctopusStepTemplateCi/Cmdlets/Interface/Sync-StepTemplate.ps1
+++ b/OctopusStepTemplateCi/Cmdlets/Interface/Sync-StepTemplate.ps1
@@ -53,6 +53,10 @@ function Sync-StepTemplate
 
     )
 
+    $ErrorActionPreference = "Stop";
+    $ProgressPreference = "SilentlyContinue";
+    Set-StrictMode -Version "Latest";
+
     $newStepTemplate = Read-StepTemplate -Path $Path;
     $templateName = $newStepTemplate.Name;
 
@@ -91,10 +95,17 @@ function Sync-StepTemplate
 
         if( Compare-StepTemplate -OldTemplate $stepTemplate -NewTemplate $newStepTemplate )
         {
+
             Write-TeamCityBuildLogMessage "Step template '$templateName' has changed. Updating";
-            $newStepTemplate.Version = $stepTemplate.Version + 1;
+
+            if( $newStepTemplate.ContainsKey("Version") )
+            {
+                $newStepTemplate.Remove("Version");
+            }
+
             $stepTemplate = Update-OctopusApiActionTemplate -ObjectId $stepTemplate.Id -Object $newStepTemplate;
             $result.UploadCount++;
+
         }
         else
         {

--- a/build/Invoke-PesterTests.ps1
+++ b/build/Invoke-PesterTests.ps1
@@ -24,19 +24,18 @@ $packagesRoot = [System.IO.Path]::Combine($rootFolder, "packages");
 Invoke-NuGetInstall -NuGet           $NuGet `
                     -Source          "https://www.powershellgallery.com/api/v2" `
                     -PackageId       "PSScriptAnalyzer" `
-                    -OutputDirectory $packagesRoot `
-                    -ExcludeVersion;
+                    -Version         "1.17.1" `
+                    -OutputDirectory $packagesRoot;
 
 Invoke-NuGetInstall -NuGet           $NuGet `
                     -Source          "https://www.powershellgallery.com/api/v2" `
                     -PackageId       "Pester" `
-                    -Version         "4.0.8" `
-                    -OutputDirectory $packagesRoot `
-                    -ExcludeVersion;
+                    -Version         "4.3.1" `
+                    -OutputDirectory $packagesRoot;
 
 
-Import-Module -Name ([System.IO.Path]::Combine($packagesRoot, "PSScriptAnalyzer"))      -ErrorAction "Stop";
-Import-Module -Name ([System.IO.Path]::Combine($packagesRoot, "Pester"))                -ErrorAction "Stop";
+Import-Module -Name ([System.IO.Path]::Combine($packagesRoot, "PSScriptAnalyzer.1.17.1\PSScriptAnalyzer.psd1")) -ErrorAction "Stop";
+Import-Module -Name ([System.IO.Path]::Combine($packagesRoot, "Pester.4.3.1\tools\Pester.psd1")) -ErrorAction "Stop";
 
 
 $testPath      = [System.IO.Path]::Combine($rootFolder, "OctopusStepTemplateCi\Cmdlets");
@@ -46,6 +45,7 @@ $coverageFiles = (Get-ChildItem -Path "$testPath\*.ps1" -Recurse -Exclude *.Test
 Import-Module -Name "$rootFolder\OctopusStepTemplateCi" -ErrorAction "Stop";
 
 
+write-host "invoking pester tests";
 $testResults = Invoke-Pester -Path         $testPath `
                              -OutputFile   "PesterTestOutput.xml" `
                              -OutputFormat "NUnitXml" `


### PR DESCRIPTION
Improved error handling so the sync process no longer crashes when a step template fails to upload - the process now skips over to the next step template instead.

Also upgraded the version of PSScriptAnalyzer and Pester used in build scripts, and fixed them to a specific version.